### PR TITLE
feat: Adding blank issue form template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.yml
+++ b/.github/ISSUE_TEMPLATE/blank_issue.yml
@@ -1,5 +1,5 @@
 name: Blank Issue
-description: Create a new issue from scratch.
+description: Create a new issue from scratch for optimization-zone.
 title: "[ISSUE]: "
 labels: ["generic"]
 body:


### PR DESCRIPTION
Adding a YAML issue form for a blank issue to replace the default github blank issue. 


Preview - 

<img width="868" height="860" alt="image" src="https://github.com/user-attachments/assets/21667921-a4f1-49ea-b99f-b443e76b6653" />
