### PR TITLE
Add AMX with TensorFlow quick-start guides and AI use-case examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ We aim to provide a dynamic resource where users can find the latest optimizatio
   - [Spark](software/spark/README.md)
   - [MySQL & PostgreSQL](software/mysql-postgresql/README.md)
   - [Kafka](software/kafka/README.md)
+  - [TensorFlow](software/tensorflow/)
+    - [ResNet50 – Computer Vision](software/tensorflow/computer-vision-resnet50/README.md)
+    - [BERT – NLP](software/tensorflow/nlp-transformers-bert/README.md)
+    - [RGAT – Graph Neural Networks](software/tensorflow/graph-neural-networks-rgat/README.md)
 - Workloads
   - [Cassandra Stress](workloads/cassandra-stress/README.md)
   - [HPC](workloads/hpc/README.md)

--- a/software/tensorflow/README.md
+++ b/software/tensorflow/README.md
@@ -1,0 +1,112 @@
+# Quick Start: AMX with TensorFlow
+
+Follow these steps to set up TensorFlow with Intel AMX acceleration (BF16 / FP16).
+
+## 1. (Recommended) Create and activate a virtual environment
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+```
+
+## 2. Install TensorFlow
+```bash
+pip install --upgrade tensorflow
+```
+For platform-specific guidance, see: https://www.tensorflow.org/install
+
+## 3. Verify the installation
+```bash
+python -c "import tensorflow as tf; print(tf.reduce_sum(tf.random.normal([1000, 1000])))"
+```
+
+---
+
+
+# Sample: Matrix Multiplication with AMX
+
+The example below benchmarks BF16 matrix multiplication.
+
+Notes:
+- BF16 mixed precision: broadly supported on AMX‑enabled Intel CPUs.
+- FP16 mixed precision: supported only on Intel® Xeon® 6 processors.
+
+```python
+import os
+import time
+import tensorflow as tf
+
+# (Optional) Verbose oneDNN logging for verification
+# os.environ["ONEDNN_VERBOSE"] = "1"
+
+# Configuration (adjust as needed)
+BATCH_SIZE = 32
+INPUT_FEATURES = 4096
+HIDDEN_FEATURES = 4096
+NUM_ITERATIONS = 10
+
+# Initialize random tensors (BF16)
+A = tf.random.uniform([BATCH_SIZE, INPUT_FEATURES], dtype=tf.bfloat16)
+B = tf.random.uniform([INPUT_FEATURES, HIDDEN_FEATURES], dtype=tf.bfloat16)
+
+# Benchmark loop
+total_time = 0.0
+for i in range(NUM_ITERATIONS):
+  start = time.time()
+  C = tf.matmul(A, B)  # utilizes AMX via oneDNN optimized kernels
+  elapsed = time.time() - start
+  total_time += elapsed
+  print(f"Iteration {i+1}: {elapsed:.6f} seconds")
+
+print(f"Average execution time: {total_time / NUM_ITERATIONS:.6f} seconds")
+```
+
+---
+
+## Verifying AMX Utilization
+
+Enable oneDNN verbose output before running the script:
+
+```bash
+export ONEDNN_VERBOSE=1
+python your_script.py
+```
+
+Or set inside the script:
+```python
+os.environ["ONEDNN_VERBOSE"] = "1"
+```
+
+Look for lines indicating AMX usage (example excerpt):
+```
+onednn_verbose,v1,info,oneDNN v3.7.3 (commit N/A)
+onednn_verbose,v1,info,cpu,isa:Intel AVX-512 with float16, Intel DL Boost and bfloat16 support and Intel AMX with bfloat16 and 8-bit integer support
+onednn_verbose,v1,primitive,exec,cpu,matmul,brg_matmul:avx10_1_512_amx,...
+Iteration 1: 0.012289 seconds
+...
+Average execution time: 0.001941 seconds
+```
+
+Key indicator: **`brg_matmul:avx10_1_512_amx`** (or similar) confirming AMX-backed BF16 matmul.
+
+---
+
+## Troubleshooting
+
+- Missing AMX indicators: Ensure CPU supports AMX and kernel/OS has AMX enabled (XSAVE/XFD configured).
+- Slow first iteration: Expected due to cache warmup.
+- To test FP16 (Xeon 6 onwards): Replace `tf.bfloat16` dtypes with `tf.float16`.
+
+This completes the setup and verification workflow.
+
+---
+
+# Leveraging AMX for different AI Use-Cases
+
+For guidance on how to enable AMX for different AI use-cases, follow the links below:
+
+| Use Case | Model | Description | README |
+|----------|-------|-------------|--------|
+| Natural Language Processing | BERT-Large (Uncased) | Sequence classification with mixed BF16 | [Link](./nlp-transformers-bert/README.md) |
+| Graph Neural Networks | R-GAT | Relational graph attention network inference | Link (TODO(othakkar): add README) |
+| Computer Vision | ResNet50 v1.5 | Image classification (CNN) with AMX BF16/FP16 | Link (TODO(othakkar): add README) |

--- a/software/tensorflow/README.md
+++ b/software/tensorflow/README.md
@@ -107,6 +107,6 @@ For guidance on how to enable AMX for different AI use-cases, follow the links b
 
 | Use Case | Model | Description | README |
 |----------|-------|-------------|--------|
-| Natural Language Processing | BERT-Large (Uncased) | Sequence classification with mixed BF16 | [Link](./nlp-transformers-bert/README.md) |
+| Natural Language Processing | BERT-Large (Uncased) | Sequence classification | [Link](./nlp-transformers-bert/README.md) |
 | Graph Neural Networks | R-GAT | Relational graph attention network inference | [Link](./graph-neural-networks-rgat/README.md) |
-| Computer Vision | ResNet50 v1.5 | Image classification (CNN) with AMX BF16/FP16 | [Link](./computer-vision-resnet50/README.md) |
+| Computer Vision | ResNet50 v1.5 | Image classification (CNN) | [Link](./computer-vision-resnet50/README.md) |

--- a/software/tensorflow/README.md
+++ b/software/tensorflow/README.md
@@ -108,5 +108,5 @@ For guidance on how to enable AMX for different AI use-cases, follow the links b
 | Use Case | Model | Description | README |
 |----------|-------|-------------|--------|
 | Natural Language Processing | BERT-Large (Uncased) | Sequence classification with mixed BF16 | [Link](./nlp-transformers-bert/README.md) |
-| Graph Neural Networks | R-GAT | Relational graph attention network inference | Link (TODO(othakkar): add README) |
-| Computer Vision | ResNet50 v1.5 | Image classification (CNN) with AMX BF16/FP16 | Link (TODO(othakkar): add README) |
+| Graph Neural Networks | R-GAT | Relational graph attention network inference | [Link](./graph-neural-networks-rgat/README.md) |
+| Computer Vision | ResNet50 v1.5 | Image classification (CNN) with AMX BF16/FP16 | [Link](./computer-vision-resnet50/README.md) |

--- a/software/tensorflow/computer-vision-resnet50/README.md
+++ b/software/tensorflow/computer-vision-resnet50/README.md
@@ -1,0 +1,206 @@
+# Computer Vision (CV): Inference with ResNet50 v1.5
+
+ResNet50 (Residual Network with 50 layers) is a convolutional neural network pretrained on ImageNet for image classification. This example shows how to run ResNet50 v1.5 (Keras built-in) for 1000-class image classification on Intel Xeon processors with AMX acceleration using `bfloat16` mixed precision.
+
+### Prerequisites
+
+- Intel Xeon 4th Gen (or newer) with AMX `bfloat16` support
+- Python environment with `pip`
+- Internet access to download model weights
+
+### Install Required Packages
+
+(Exact versions ensure consistency.)
+
+```bash
+pip install tensorflow==2.21.0
+```
+
+## Quick Start: Keras Mixed Precision
+
+To reuse the standard `float32` (pretrained) ResNet50 model while executing layers in `bfloat16` on AMX, enable a `mixed_bfloat16` policy BEFORE creating/loading the model. This keeps model weights in `float32` for stability while executing math (matmul, convolution, batch norm) in `bfloat16` on AMX-capable Intel Xeon processors. Note that this approach to enable auto-mixed precision can be used for any Keras model.
+
+```python
+import numpy as np
+import tensorflow as tf
+import keras
+
+# 1. Enable AMX via bfloat16 Mixed Precision
+# Set this BEFORE loading the model so all layers use bfloat16 compute with float32 weights.
+keras.mixed_precision.set_global_policy("mixed_bfloat16")
+
+# 2. Load pretrained ResNet50 (ImageNet weights, 1000 classes)
+model = keras.applications.ResNet50(weights="imagenet")
+
+# 3. Create a dummy input image (224x224x3, batch of 1)
+# In production, use keras.utils.load_img() and keras.applications.resnet50.preprocess_input().
+dummy_image = np.random.rand(1, 224, 224, 3).astype(np.float32)
+preprocessed = keras.applications.resnet50.preprocess_input(dummy_image)
+
+# 4. Run Inference
+predictions = model(preprocessed, training=False)
+logits = tf.cast(predictions, tf.float32)  # ensure float32 for downstream usage
+
+top5 = tf.math.top_k(logits, k=5)
+print("Top-5 class indices:", top5.indices.numpy())
+print("Top-5 logits:", top5.values.numpy())
+```
+
+Notes:
+- Set `ONEDNN_VERBOSE=1` to confirm AMX usage (look for `brg_matmul ... amx`).
+- Revert to full `float32` by removing the policy or setting `mixed_precision` to `float32`.
+
+## Deploying with TensorFlow Serving (`bfloat16` Auto Mixed Precision)
+
+### Export the Model (`SavedModel`, `float32` weights)
+
+> **Note:** We don't need to explicitly enable `bfloat16` mixed precision with Keras while exporting the model, because the `--mixed_precision=bfloat16` flag passed when starting the inference server handles that automatically (see [Start the Server (Enable `bfloat16`)](#start-the-server-enable-bfloat16) below).
+
+Create `export_resnet50.py`:
+
+```python
+import numpy as np
+import tensorflow as tf
+import keras
+
+model = keras.applications.ResNet50(weights="imagenet")
+
+# Export the model in float32 format.
+output_model_path = "/tmp/resnet50/1"
+model.export(output_model_path)
+print("Exported to:", output_model_path)
+```
+
+Run:
+
+```bash
+python export_resnet50.py
+```
+
+### Pull TensorFlow Serving
+
+(Using the official CPU image.)
+
+```bash
+docker pull tensorflow/serving
+```
+
+Reference setup guide: https://github.com/tensorflow/serving?tab=readme-ov-file#set-up
+
+### Start the Server (Enable `bfloat16`)
+
+TensorFlow Serving (CPU) currently supports `bfloat16` mixed precision (`fp16` not yet enabled for CPU on TensorFlow Serving).
+
+```bash
+docker run -t --rm \
+  -p 8501:8501 \
+  -v /tmp/resnet50:/models/resnet50 \
+  -e MODEL_NAME=resnet50 \
+  -e ONEDNN_VERBOSE=1 \
+  tensorflow/serving --mixed_precision=bfloat16
+```
+
+Sample log indicators:
+- `auto_mixed_precision_onednn_bfloat16` graph optimizer
+- `brg_matmul` with `amx` and `src_bf16` / `wei_bf16`
+
+```bash
+I0000 00:00:0000000000.000000     905 auto_mixed_precision.cc:2335] Running auto_mixed_precision_onednn_bfloat16 graph optimizer
+I0000 00:00:0000000000.000000     905 auto_mixed_precision.cc:2263] Converted N/M nodes to bfloat16 precision using K cast(s) to bfloat16 (excluding Const and Variable casts)
+```
+
+Troubleshooting 403:
+- Ensure the URL model name matches `MODEL_NAME`.
+- Check container logs: `docker logs <id>`.
+- Disable proxies: `export no_proxy=localhost,127.0.0.1`.
+
+## Client Inference (REST)
+
+Install:
+
+```bash
+pip install requests==2.33.1 numpy==2.4.4
+```
+
+Create `infer_resnet50.py`:
+
+```python
+import requests, json, numpy as np
+
+# Create a dummy input image (224x224x3, batch of 1)
+# In production, load a real image and convert to list.
+dummy_image = np.random.rand(1, 224, 224, 3).astype(np.float32)
+
+payload = {
+  "instances": dummy_image.tolist()
+}
+
+resp = requests.post(
+  "http://127.0.0.1:8501/v1/models/resnet50:predict",
+  data=json.dumps(payload),
+  headers={"content-type": "application/json"},
+  proxies={"http": None, "https": None}
+)
+
+if resp.status_code == 200:
+  preds = np.array(resp.json()["predictions"])
+  top5_indices = np.argsort(preds[0])[-5:][::-1]
+  top5_logits = preds[0][top5_indices]
+  print("Inference successful!")
+  print("Top-5 class indices:", top5_indices)
+  print("Top-5 logits:", top5_logits)
+else:
+  print("Error:", resp.status_code, resp.text)
+```
+
+Run:
+
+```bash
+python infer_resnet50.py
+```
+
+**Expected Logs on the Server**
+
+```bash
+I0000 00:00:0000000000.000000    3797 auto_mixed_precision.cc:2335] Running auto_mixed_precision_onednn_bfloat16 graph optimizer
+I0000 00:00:0000000000.000000    3797 auto_mixed_precision.cc:2263] Converted N/M nodes to bfloat16 precision using K cast(s) to bfloat16 (excluding Const and Variable casts)
+```
+
+**Expected Logs on the Client**
+
+Top-5 class indices and logits for ImageNet classification (random input will give arbitrary results).
+
+```
+Inference successful!
+Top-5 class indices: [916 530 851 644 664]
+Top-5 logits: [0.05151367 0.046875   0.04541016 0.04272461 0.03881836]
+```
+
+## Optional: Graph Freezing for Additional Performance
+
+Freeze variables to constants for a lean inference graph (removes variable-loading overhead).
+
+**Script (public reference):**
+https://raw.githubusercontent.com/oneapi-src/oneAPI-samples/master/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_InferenceOptimization/scripts/freeze_optimize_v2.py
+
+**Example:**
+
+```bash
+python freeze_optimize.py \
+  --input_saved_model_dir=/tmp/resnet50/1 \
+  --output_saved_model_dir=/tmp/resnet50_frozen/1
+```
+
+Run this after exporting the `SavedModel` (server side).
+
+----------------------------------------------------------------------
+Key Validation Steps
+----------------------------------------------------------------------
+- **Functional:** REST returns logits JSON with 1000 class scores
+- **Precision:** Logs show `auto_mixed_precision_onednn_bfloat16`
+- **AMX:** `ONEDNN_VERBOSE` lines include `amx` and `bf16` datatypes
+- **Rollback:** Remove `--mixed_precision` flag on TF Serving; delete policy in Keras path
+
+----------------------------------------------------------------------
+Summary:
+Enabled `bfloat16` mixed precision for ResNet50 on Xeon with minimal code change, deployed via TensorFlow Serving, verified AMX acceleration, and optionally optimized the model by freezing the graph.

--- a/software/tensorflow/computer-vision-resnet50/README.md
+++ b/software/tensorflow/computer-vision-resnet50/README.md
@@ -1,16 +1,32 @@
 # Computer Vision (CV): Inference with ResNet50 v1.5
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Install Required Packages](#install-required-packages)
+- [Quick Start: Keras Mixed Precision](#quick-start-keras-mixed-precision)
+- [Deploying with TensorFlow Serving (bfloat16 Auto Mixed Precision)](#deploying-with-tensorflow-serving-bfloat16-auto-mixed-precision)
+  - [Export the Model (SavedModel, float32 weights)](#export-the-model-savedmodel-float32-weights)
+  - [Pull TensorFlow Serving](#pull-tensorflow-serving)
+  - [Start the Server (Enable bfloat16)](#start-the-server-enable-bfloat16)
+- [Client Inference (REST)](#client-inference-rest)
+- [Optional: Graph Freezing for Additional Performance](#optional-graph-freezing-for-additional-performance)
+- [Key Validation Steps](#key-validation-steps)
+
+## Overview
+
 ResNet50 (Residual Network with 50 layers) is a convolutional neural network pretrained on ImageNet for image classification. This example shows how to run ResNet50 v1.5 (Keras built-in) for 1000-class image classification on Intel Xeon processors with AMX acceleration using `bfloat16` mixed precision.
 
-### Prerequisites
+## Prerequisites
 
 - Intel Xeon 4th Gen (or newer) with AMX `bfloat16` support
 - Python environment with `pip`
 - Internet access to download model weights
 
-### Install Required Packages
+## Install Required Packages
 
-(Exact versions ensure consistency.)
+Pinned versions are shown below for reproducibility.
 
 ```bash
 pip install tensorflow==2.21.0
@@ -79,7 +95,7 @@ python export_resnet50.py
 
 ### Pull TensorFlow Serving
 
-(Using the official CPU image.)
+Pull the official TensorFlow Serving CPU image:
 
 ```bash
 docker pull tensorflow/serving
@@ -193,14 +209,13 @@ python freeze_optimize.py \
 
 Run this after exporting the `SavedModel` (server side).
 
-----------------------------------------------------------------------
-Key Validation Steps
-----------------------------------------------------------------------
+## Key Validation Steps
+
 - **Functional:** REST returns logits JSON with 1000 class scores
 - **Precision:** Logs show `auto_mixed_precision_onednn_bfloat16`
 - **AMX:** `ONEDNN_VERBOSE` lines include `amx` and `bf16` datatypes
 - **Rollback:** Remove `--mixed_precision` flag on TF Serving; delete policy in Keras path
 
-----------------------------------------------------------------------
-Summary:
+## Summary:
+
 Enabled `bfloat16` mixed precision for ResNet50 on Xeon with minimal code change, deployed via TensorFlow Serving, verified AMX acceleration, and optionally optimized the model by freezing the graph.

--- a/software/tensorflow/computer-vision-resnet50/README.md
+++ b/software/tensorflow/computer-vision-resnet50/README.md
@@ -21,6 +21,7 @@ ResNet50 (Residual Network with 50 layers) is a convolutional neural network pre
 ## Prerequisites
 
 - Intel Xeon 4th Gen (or newer) with AMX `bfloat16` support
+- Docker (for TensorFlow Serving deployment)
 - Python environment with `pip`
 - Internet access to download model weights
 
@@ -201,8 +202,8 @@ https://raw.githubusercontent.com/oneapi-src/oneAPI-samples/master/AI-and-Analyt
 
 **Example:**
 
-```bash
-python freeze_optimize.py \
+```
+python freeze_optimize_v2.py \
   --input_saved_model_dir=/tmp/resnet50/1 \
   --output_saved_model_dir=/tmp/resnet50_frozen/1
 ```

--- a/software/tensorflow/graph-neural-networks-rgat/README.md
+++ b/software/tensorflow/graph-neural-networks-rgat/README.md
@@ -1,0 +1,309 @@
+# Graph Neural Networks (GNN): Inference with RGAT using TF-GNN
+RGAT (Relational Graph Attention Network) leverages multi-head attention over typed edges to learn rich node representations on heterogeneous graphs, capturing the unique importance of different relationship types. This example shows how to run an RGAT-style model using TensorFlow GNN (TF-GNN) on Intel Xeon processors with AMX acceleration using `bfloat16` mixed precision.
+
+### Prerequisites
+- Intel Xeon 4th Gen (or newer) with AMX `bfloat16` support
+- Python environment with `pip`
+- Internet access to download packages
+
+### Install Required Packages
+(Exact versions ensure consistency.)
+```bash
+pip install tensorflow==2.21.0
+pip install tf-keras==2.21.0 --no-deps
+pip install tensorflow-gnn==1.0.3
+```
+
+### Keras Version Compatibility
+
+`tensorflow_gnn` requires **Keras 2** (the legacy Keras API). TensorFlow 2.16+ ships with Keras 3 by default, which is **not compatible** with `tensorflow_gnn`. Before running any script, you must set the following environment variable to force TensorFlow to use the legacy Keras 2 backend:
+
+```bash
+export TF_USE_LEGACY_KERAS=1
+```
+
+## Enable `bfloat16` Mixed Precision with AMX
+
+To execute GNN layers in `bfloat16` on AMX, enable a `mixed_bfloat16` policy BEFORE creating the model. This keeps model weights in `float32` for numerical stability while executing math (`matmul`, attention, feed-forward) in `bfloat16` on AMX-capable Intel Xeon processors. Note that this approach to enable auto-mixed precision can be used for any Keras model, including graph neural networks built with TF-GNN.
+
+```python
+import os
+# Ensure legacy Keras is being used (required by tensorflow_gnn)
+os.environ["TF_USE_LEGACY_KERAS"] = "1"
+
+import tensorflow as tf
+import tensorflow_gnn as tfgnn
+from tensorflow_gnn.models.gat_v2 import GATv2Conv
+from tensorflow.keras import mixed_precision
+
+# 1. Enable AMX via bfloat16 Mixed Precision
+# Setting this BEFORE model creation keeps weights in float32 for stability
+# while executing matmul, attention, and feed-forward ops in bfloat16 on AMX.
+mixed_precision.set_global_policy("mixed_bfloat16")
+
+# 2. Build a graph: 512 nodes, 2048 edges, 256-dim features
+num_nodes = 512
+num_edges = 2048
+hidden_dim = 256
+
+graph = tfgnn.GraphTensor.from_pieces(
+    node_sets={
+        "paper": tfgnn.NodeSet.from_fields(
+            sizes=tf.constant([num_nodes]),
+            features={tfgnn.HIDDEN_STATE: tf.random.normal([num_nodes, hidden_dim])}
+        )
+    },
+    edge_sets={
+        "cites": tfgnn.EdgeSet.from_fields(
+            sizes=tf.constant([num_edges]),
+            features={},
+            adjacency=tfgnn.Adjacency.from_indices(
+                source=("paper", tf.random.uniform([num_edges], 0, num_nodes, dtype=tf.int32)),
+                target=("paper", tf.random.uniform([num_edges], 0, num_nodes, dtype=tf.int32))
+            )
+        )
+    }
+)
+
+# 3. Define RGAT model (single GATv2Conv layer)
+input_graph = tf.keras.layers.Input(type_spec=graph.spec)
+output_graph = tfgnn.keras.layers.GraphUpdate(
+    node_sets={
+        "paper": tfgnn.keras.layers.NodeSetUpdate(
+            edge_set_inputs={
+                "cites": GATv2Conv(
+                    num_heads=8,
+                    per_head_channels=32,
+                    receiver_tag=tfgnn.TARGET
+                )
+            },
+            next_state=tfgnn.keras.layers.NextStateFromConcat(
+                tf.keras.layers.Dense(hidden_dim)
+            )
+        )
+    }
+)(input_graph)
+model = tf.keras.Model(input_graph, output_graph)
+
+# 4. Run Inference
+# In a real scenario, load trained weights here via model.load_weights().
+output = model(graph)
+result = tf.cast(output.node_sets["paper"][tfgnn.HIDDEN_STATE], tf.float32)
+
+print("Output shape:", result.shape)
+print("Compute dtype:", output.node_sets["paper"][tfgnn.HIDDEN_STATE].dtype)
+print("Result dtype (cast):", result.dtype)
+```
+
+Notes:
+- Set `ONEDNN_VERBOSE=1` to confirm AMX usage (look for `brg_matmul ... amx`).
+- Revert to full `float32` by removing the policy or setting `mixed_precision` to `float32`.
+
+## Deploying with TensorFlow Serving (`bfloat16` Auto Mixed Precision)
+
+### Export the Model (`SavedModel`, `float32` weights)
+
+TF-GNN models consume `GraphTensor` (a composite tensor). To export a usable `SavedModel` for TF Serving, define a `tf.function` signature that accepts flat tensors and reassembles the graph internally.
+> **Note:** We don't need to explicitly enable `bfloat16` mixed precision with Keras while exporting the model, because the `--mixed_precision=bfloat16` flag passed when starting the inference server handles that automatically (see [Start the Server (Enable `bfloat16`)](#start-the-server-enable-bfloat16) below).
+
+Create `export_rgat.py`:
+```python
+import os
+# Ensure legacy Keras is being used (required by tensorflow_gnn)
+os.environ["TF_USE_LEGACY_KERAS"] = "1"
+
+import tensorflow as tf
+import tensorflow_gnn as tfgnn
+from tensorflow_gnn.models.gat_v2 import GATv2Conv
+from tensorflow.keras import mixed_precision
+
+# Build a sample graph to derive the spec
+num_nodes = 512
+num_edges = 2048
+hidden_dim = 256
+
+sample_graph = tfgnn.GraphTensor.from_pieces(
+    node_sets={
+        "paper": tfgnn.NodeSet.from_fields(
+            sizes=tf.constant([num_nodes]),
+            features={tfgnn.HIDDEN_STATE: tf.random.normal([num_nodes, hidden_dim])}
+        )
+    },
+    edge_sets={
+        "cites": tfgnn.EdgeSet.from_fields(
+            sizes=tf.constant([num_edges]),
+            features={},
+            adjacency=tfgnn.Adjacency.from_indices(
+                source=("paper", tf.random.uniform([num_edges], 0, num_nodes, dtype=tf.int32)),
+                target=("paper", tf.random.uniform([num_edges], 0, num_nodes, dtype=tf.int32))
+            )
+        )
+    }
+)
+
+# Define the RGAT model
+input_graph = tf.keras.layers.Input(type_spec=sample_graph.spec)
+output_graph = tfgnn.keras.layers.GraphUpdate(
+    node_sets={
+        "paper": tfgnn.keras.layers.NodeSetUpdate(
+            edge_set_inputs={
+                "cites": GATv2Conv(
+                    num_heads=8,
+                    per_head_channels=32,
+                    receiver_tag=tfgnn.TARGET
+                )
+            },
+            next_state=tfgnn.keras.layers.NextStateFromConcat(
+                tf.keras.layers.Dense(hidden_dim)
+            )
+        )
+    }
+)(input_graph)
+model = tf.keras.Model(input_graph, output_graph)
+
+# Define a flat-tensor serving signature
+# TF-GNN models consume GraphTensor (a composite tensor). This serving function
+# accepts plain tensors and reassembles the GraphTensor internally.
+@tf.function(input_signature=[
+    tf.TensorSpec([None, 256], tf.float32, name="paper_features"),
+    tf.TensorSpec([None], tf.int32, name="cites_source"),
+    tf.TensorSpec([None], tf.int32, name="cites_target"),
+])
+def serving_fn(paper_features, cites_source, cites_target):
+    num_nodes = tf.shape(paper_features)[0]
+    num_edges = tf.shape(cites_source)[0]
+    g = tfgnn.GraphTensor.from_pieces(
+        node_sets={
+            "paper": tfgnn.NodeSet.from_fields(
+                sizes=tf.expand_dims(num_nodes, axis=0),
+                features={tfgnn.HIDDEN_STATE: paper_features}
+            )
+        },
+        edge_sets={
+            "cites": tfgnn.EdgeSet.from_fields(
+                sizes=tf.expand_dims(num_edges, axis=0),
+                features={},
+                adjacency=tfgnn.Adjacency.from_indices(
+                    source=("paper", cites_source),
+                    target=("paper", cites_target)
+                )
+            )
+        }
+    )
+    out = model(g)
+    logits = tf.cast(out.node_sets["paper"][tfgnn.HIDDEN_STATE], tf.float32)
+    return {"logits": logits}
+
+# Export as versioned SavedModel (version subdirectory required by TF Serving)
+output_model_path = "/tmp/rgat_model/1"
+tf.saved_model.save(model, output_model_path, signatures={"serving_default": serving_fn})
+print("Exported to:", output_model_path)
+```
+Run:
+```bash
+python export_rgat.py
+```
+
+### Pull TensorFlow Serving
+(Using the official CPU image.)
+```bash
+docker pull tensorflow/serving
+```
+Reference setup guide: https://github.com/tensorflow/serving?tab=readme-ov-file#set-up
+
+### Start the Server (Enable `bfloat16`)
+TensorFlow Serving (CPU) currently supports `bfloat16` mixed precision (`fp16` not yet enabled for CPU on TensorFlow Serving).
+```bash
+docker run -t --rm \
+  -p 8501:8501 \
+  -v /tmp/rgat_model:/models/rgat_model \
+  -e MODEL_NAME=rgat_model \
+  -e ONEDNN_VERBOSE=1 \
+  tensorflow/serving --mixed_precision=bfloat16
+```
+Sample log indicators:
+- `auto_mixed_precision_onednn_bfloat16` graph optimizer
+- `brg_matmul` with `amx` and `src_bf16` / `wei_bf16`
+
+```bash
+I0000 00:00:0000000000.000000     100 auto_mixed_precision.cc:2335] Running auto_mixed_precision_onednn_bfloat16 graph optimizer
+I0000 00:00:0000000000.000000     100 auto_mixed_precision.cc:2263] Converted N/M nodes to bfloat16 precision using K cast(s) to bfloat16 (excluding Const and Variable casts)
+```
+
+Troubleshooting 403:
+- Ensure URL model name matches `MODEL_NAME`.
+- Check container logs: `docker logs <id>`.
+- Disable proxies: `export no_proxy=localhost,127.0.0.1`.
+
+## Client Inference (REST)
+
+Install:
+```bash
+pip install requests==2.33.1 numpy==2.4.4
+```
+
+Create `infer_rgat.py`:
+```python
+import requests, json, numpy as np
+
+num_nodes, num_edges, hidden_dim = 4, 5, 64
+
+payload = {
+    "instances": [{
+        "paper_sizes": [num_nodes],
+        "paper_features": np.random.randn(num_nodes, hidden_dim).tolist(),
+        "cites_sizes": [num_edges],
+        "cites_source": [0, 1, 2, 3, 0],
+        "cites_target": [1, 2, 3, 0, 2]
+    }]
+}
+
+resp = requests.post(
+    "http://127.0.0.1:8501/v1/models/rgat_model:predict",
+    data=json.dumps(payload),
+    headers={"content-type": "application/json"},
+    proxies={"http": None, "https": None}
+)
+
+if resp.status_code == 200:
+    preds = np.array(resp.json()["predictions"])
+    print("Inference successful!")
+    print("Output shape:", preds.shape)
+    print("First node logits:", preds[0][:5], "...")
+else:
+    print("Error:", resp.status_code, resp.text)
+```
+Run:
+```bash
+python infer_rgat.py
+```
+
+**Expected Logs on the Server**
+
+```bash
+I0000 00:00:0000000000.000000    100 auto_mixed_precision.cc:2335] Running auto_mixed_precision_onednn_bfloat16 graph optimizer
+I0000 00:00:0000000000.000000    100 auto_mixed_precision.cc:2263] Converted N/M nodes to bfloat16 precision using K cast(s) to bfloat16 (excluding Const and Variable casts)
+```
+
+**Expected Logs on the Client**
+
+Output logits for each node (untrained weights will give random results).
+
+```
+Inference successful!
+Output shape: (512, 256)
+First node logits: [-0.67578125 -0.15625     0.38867188 -0.55859375  1.46875   ] ...
+```
+
+----------------------------------------------------------------------
+Key Validation Steps
+----------------------------------------------------------------------
+- **Functional:** REST returns logits JSON for each node
+- **Precision:** Logs show `auto_mixed_precision_onednn_bfloat16`
+- **AMX:** `ONEDNN_VERBOSE` lines include `amx` and `bf16` datatypes
+- **Rollback:** Remove `--mixed_precision` flag; delete policy in Keras path
+
+----------------------------------------------------------------------
+Summary:
+Enabled `bfloat16` mixed precision for an RGAT model on Xeon with minimal code change using TF-GNN's `GATv2Conv`, deployed via TensorFlow Serving, and verified AMX acceleration.
+

--- a/software/tensorflow/graph-neural-networks-rgat/README.md
+++ b/software/tensorflow/graph-neural-networks-rgat/README.md
@@ -1,13 +1,33 @@
 # Graph Neural Networks (GNN): Inference with RGAT using TF-GNN
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Install Required Packages](#install-required-packages)
+- [Keras Version Compatibility](#keras-version-compatibility)
+- [Quick Start: Keras Mixed Precision](#quick-start-keras-mixed-precision)
+- [Deploying with TensorFlow Serving (bfloat16 Auto Mixed Precision)](#deploying-with-tensorflow-serving-bfloat16-auto-mixed-precision)
+  - [Export the Model (SavedModel, float32 weights)](#export-the-model-savedmodel-float32-weights)
+  - [Pull TensorFlow Serving](#pull-tensorflow-serving)
+  - [Start the Server (Enable bfloat16)](#start-the-server-enable-bfloat16)
+- [Client Inference (REST)](#client-inference-rest)
+- [Key Validation Steps](#key-validation-steps)
+
+## Overview
+
 RGAT (Relational Graph Attention Network) leverages multi-head attention over typed edges to learn rich node representations on heterogeneous graphs, capturing the unique importance of different relationship types. This example shows how to run an RGAT-style model using TensorFlow GNN (TF-GNN) on Intel Xeon processors with AMX acceleration using `bfloat16` mixed precision.
 
-### Prerequisites
+## Prerequisites
+
 - Intel Xeon 4th Gen (or newer) with AMX `bfloat16` support
 - Python environment with `pip`
 - Internet access to download packages
 
-### Install Required Packages
-(Exact versions ensure consistency.)
+## Install Required Packages
+
+Pinned versions are shown below for reproducibility.
+
 ```bash
 pip install tensorflow==2.21.0
 pip install tf-keras==2.21.0 --no-deps
@@ -22,7 +42,7 @@ pip install tensorflow-gnn==1.0.3
 export TF_USE_LEGACY_KERAS=1
 ```
 
-## Enable `bfloat16` Mixed Precision with AMX
+## Quick Start: Keras Mixed Precision
 
 To execute GNN layers in `bfloat16` on AMX, enable a `mixed_bfloat16` policy BEFORE creating the model. This keeps model weights in `float32` for numerical stability while executing math (`matmul`, attention, feed-forward) in `bfloat16` on AMX-capable Intel Xeon processors. Note that this approach to enable auto-mixed precision can be used for any Keras model, including graph neural networks built with TF-GNN.
 
@@ -104,9 +124,11 @@ Notes:
 ### Export the Model (`SavedModel`, `float32` weights)
 
 TF-GNN models consume `GraphTensor` (a composite tensor). To export a usable `SavedModel` for TF Serving, define a `tf.function` signature that accepts flat tensors and reassembles the graph internally.
+
 > **Note:** We don't need to explicitly enable `bfloat16` mixed precision with Keras while exporting the model, because the `--mixed_precision=bfloat16` flag passed when starting the inference server handles that automatically (see [Start the Server (Enable `bfloat16`)](#start-the-server-enable-bfloat16) below).
 
 Create `export_rgat.py`:
+
 ```python
 import os
 # Ensure legacy Keras is being used (required by tensorflow_gnn)
@@ -199,20 +221,27 @@ output_model_path = "/tmp/rgat_model/1"
 tf.saved_model.save(model, output_model_path, signatures={"serving_default": serving_fn})
 print("Exported to:", output_model_path)
 ```
+
 Run:
+
 ```bash
 python export_rgat.py
 ```
 
 ### Pull TensorFlow Serving
-(Using the official CPU image.)
+
+Pull the official TensorFlow Serving CPU image:
+
 ```bash
 docker pull tensorflow/serving
 ```
+
 Reference setup guide: https://github.com/tensorflow/serving?tab=readme-ov-file#set-up
 
 ### Start the Server (Enable `bfloat16`)
+
 TensorFlow Serving (CPU) currently supports `bfloat16` mixed precision (`fp16` not yet enabled for CPU on TensorFlow Serving).
+
 ```bash
 docker run -t --rm \
   -p 8501:8501 \
@@ -221,6 +250,7 @@ docker run -t --rm \
   -e ONEDNN_VERBOSE=1 \
   tensorflow/serving --mixed_precision=bfloat16
 ```
+
 Sample log indicators:
 - `auto_mixed_precision_onednn_bfloat16` graph optimizer
 - `brg_matmul` with `amx` and `src_bf16` / `wei_bf16`
@@ -238,11 +268,13 @@ Troubleshooting 403:
 ## Client Inference (REST)
 
 Install:
+
 ```bash
 pip install requests==2.33.1 numpy==2.4.4
 ```
 
 Create `infer_rgat.py`:
+
 ```python
 import requests, json, numpy as np
 
@@ -273,7 +305,9 @@ if resp.status_code == 200:
 else:
     print("Error:", resp.status_code, resp.text)
 ```
+
 Run:
+
 ```bash
 python infer_rgat.py
 ```
@@ -295,15 +329,13 @@ Output shape: (512, 256)
 First node logits: [-0.67578125 -0.15625     0.38867188 -0.55859375  1.46875   ] ...
 ```
 
-----------------------------------------------------------------------
-Key Validation Steps
-----------------------------------------------------------------------
+## Key Validation Steps
+
 - **Functional:** REST returns logits JSON for each node
 - **Precision:** Logs show `auto_mixed_precision_onednn_bfloat16`
 - **AMX:** `ONEDNN_VERBOSE` lines include `amx` and `bf16` datatypes
 - **Rollback:** Remove `--mixed_precision` flag; delete policy in Keras path
 
-----------------------------------------------------------------------
-Summary:
-Enabled `bfloat16` mixed precision for an RGAT model on Xeon with minimal code change using TF-GNN's `GATv2Conv`, deployed via TensorFlow Serving, and verified AMX acceleration.
+## Summary
 
+Enabled `bfloat16` mixed precision for an RGAT model on Xeon with minimal code change using TF-GNN's `GATv2Conv`, deployed via TensorFlow Serving, and verified AMX acceleration.

--- a/software/tensorflow/graph-neural-networks-rgat/README.md
+++ b/software/tensorflow/graph-neural-networks-rgat/README.md
@@ -21,8 +21,9 @@ RGAT (Relational Graph Attention Network) leverages multi-head attention over ty
 ## Prerequisites
 
 - Intel Xeon 4th Gen (or newer) with AMX `bfloat16` support
+- Docker (for TensorFlow Serving deployment)
 - Python environment with `pip`
-- Internet access to download packages
+- Internet access to download model weights
 
 ## Install Required Packages
 
@@ -278,16 +279,14 @@ Create `infer_rgat.py`:
 ```python
 import requests, json, numpy as np
 
-num_nodes, num_edges, hidden_dim = 4, 5, 64
+num_nodes, num_edges, hidden_dim = 4, 5, 256
 
 payload = {
-    "instances": [{
-        "paper_sizes": [num_nodes],
+    "inputs": {
         "paper_features": np.random.randn(num_nodes, hidden_dim).tolist(),
-        "cites_sizes": [num_edges],
         "cites_source": [0, 1, 2, 3, 0],
         "cites_target": [1, 2, 3, 0, 2]
-    }]
+    }
 }
 
 resp = requests.post(
@@ -298,7 +297,7 @@ resp = requests.post(
 )
 
 if resp.status_code == 200:
-    preds = np.array(resp.json()["predictions"])
+    preds = np.array(resp.json()["outputs"])
     print("Inference successful!")
     print("Output shape:", preds.shape)
     print("First node logits:", preds[0][:5], "...")
@@ -325,8 +324,8 @@ Output logits for each node (untrained weights will give random results).
 
 ```
 Inference successful!
-Output shape: (512, 256)
-First node logits: [-0.67578125 -0.15625     0.38867188 -0.55859375  1.46875   ] ...
+Output shape: (4, 256)
+First node logits: [0.625      2.625      0.49414062 0.9453125  0.18359375] ...
 ```
 
 ## Key Validation Steps

--- a/software/tensorflow/nlp-transformers-bert/README.md
+++ b/software/tensorflow/nlp-transformers-bert/README.md
@@ -1,18 +1,40 @@
 # Natural Language Processing (NLP): Inference with BERT-Large (Uncased)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Install Required Packages](#install-required-packages)
+- [Quick Start: Keras Mixed Precision](#quick-start-keras-mixed-precision)
+- [Deploying with TensorFlow Serving (bfloat16 Auto Mixed Precision)](#deploying-with-tensorflow-serving-bfloat16-auto-mixed-precision)
+  - [Export the Model (SavedModel, float32 weights)](#export-the-model-savedmodel-float32-weights)
+  - [Pull TensorFlow Serving](#pull-tensorflow-serving)
+  - [Start the Server (Enable bfloat16)](#start-the-server-enable-bfloat16)
+- [Client Inference (REST)](#client-inference-rest)
+- [Optional: Graph Freezing for Additional Performance](#optional-graph-freezing-for-additional-performance)
+- [Key Validation Steps](#key-validation-steps)
+
+## Overview
+
 BERT (Bidirectional Encoder Representations from Transformers) is a transformer model pretrained on large English text corpora using self-supervised objectives. This example shows how to run BERT-Large (uncased, Hugging Face) for sequence (binary) classification on Intel Xeon processors with AMX acceleration using bfloat16 (BF16) mixed precision.
 
-Prerequisites
+## Prerequisites
+
 - Intel Xeon 4th Gen (or newer) with AMX BF16 support
 - Python environment with pip
 - Internet access to download model weights
 
-### Install Required Packages
-(Exact versions ensure consistency.)
+## Install Required Packages
+
+Pinned versions are shown below for reproducibility.
+
 ```bash
 pip install tensorflow==2.20.0
 pip install tf-keras==2.20.1 --no-deps
 pip install transformers==4.49.0
 ```
+
+## Quick Start: Keras Mixed Precision
 
 To reuse the standard FP32 (pretrained) BERT-Large model while executing layers in BF16 on AMX, enable a `mixed_bfloat16` policy BEFORE creating/loading the model. This keeps model weights in FP32 for stability while executing math (matmul, attention, feed‑forward) in BF16 on AMX-capable Intel Xeon processors. Note that this approach to enable auto-mixed precision can be used for any Keras model.
 
@@ -41,15 +63,19 @@ pred = tf.argmax(logits, axis=-1)
 print("Logits:", logits.numpy())
 print("Predicted class:", pred.numpy())
 ```
+
 Notes:
-- Set ONEDNN_VERBOSE=1 to confirm AMX usage (look for brg_matmul ... amx).
+- Set `ONEDNN_VERBOSE=1` to confirm AMX usage (look for `brg_matmul ... amx`).
 - Revert to full FP32 by removing the policy or setting mixed_precision to float32.
 
-----------------------------------------------------------------------
-Deploying with TensorFlow Serving (BF16 Auto Mixed Precision)
-----------------------------------------------------------------------
+## Deploying with TensorFlow Serving (BF16 Auto Mixed Precision)
 
-1. Export the Model (SavedModel, FP32 weights)
+### Export the Model (SavedModel, FP32 weights)
+
+> **Note:** We don't need to explicitly enable `bfloat16` mixed precision with Keras while exporting the model, because the `--mixed_precision=bfloat16` flag passed when starting the inference server handles that automatically (see [Start the Server (Enable bfloat16)](#start-the-server-enable-bfloat16) below).
+
+Create `export_bert_large.py`:
+
 ```python
 import tensorflow as tf
 from transformers import TFBertForSequenceClassification, BertTokenizer
@@ -71,20 +97,27 @@ output_model_path = "/tmp/bert_large_hf/1"  # versioned directory
 model.save(output_model_path, include_optimizer=False, signatures={"serving_default": serving_fn})
 print("Exported to:", output_model_path)
 ```
+
 Run:
+
 ```bash
 python export_bert_large.py
 ```
 
-2. Pull TensorFlow Serving
-(Using the official CPU image.)
+### Pull TensorFlow Serving
+
+Pull the official TensorFlow Serving CPU image:
+
 ```bash
 docker pull tensorflow/serving
 ```
+
 Reference setup guide: https://github.com/tensorflow/serving?tab=readme-ov-file#set-up
 
-3. Start the Server (Enable BF16)
+### Start the Server (Enable BF16)
+
 TensorFlow Serving (CPU) currently supports bfloat16 mixed precision (fp16 not yet enabled for CPU).
+
 ```bash
 docker run -t --rm \
   -p 8501:8501 \
@@ -93,6 +126,7 @@ docker run -t --rm \
   -e ONEDNN_VERBOSE=1 \
   tensorflow/serving --mixed_precision=bfloat16
 ```
+
 Sample log indicators:
 - `auto_mixed_precision_onednn_bfloat16` graph optimizer
 - `brg_matmul` with `amx` and `src_bf16` / `wei_bf16`
@@ -111,16 +145,17 @@ Troubleshooting 403:
 - Check container logs: docker logs <id>.
 - Disable proxies: export no_proxy=localhost,127.0.0.1.
 
-----------------------------------------------------------------------
-Client Inference (REST)
-----------------------------------------------------------------------
+## Client Inference (REST)
+
 Install:
+
 ```bash
 pip install requests==2.32.5 numpy==2.3.3 transformers==4.49.0 tensorflow==2.20.0
 pip install tf-keras==2.20.1 --no-deps
 ```
 
-Create infer_bert_large.py:
+Create `infer_bert_large.py`:
+
 ```python
 import requests, json, numpy as np, tensorflow as tf
 from transformers import BertTokenizer
@@ -159,7 +194,9 @@ if resp.status_code == 200:
 else:
     print("Error:", resp.text)
 ```
+
 Run:
+
 ```bash
 python infer_bert_large.py
 ```
@@ -175,30 +212,30 @@ I0000 00:00:1758754431.978969    3797 auto_mixed_precision.cc:2263] Converted 18
 
 Logits and probabilities for binary classification (untrained weights will give random results):
 
-----------------------------------------------------------------------
-Optional: Graph Freezing for Additional Performance
-----------------------------------------------------------------------
+## Optional: Graph Freezing for Additional Performance
+
 Freeze variables to constants for a lean inference graph (removes variable-loading overhead).
 
-Script (public reference):
+**Script (public reference):**
 https://raw.githubusercontent.com/oneapi-src/oneAPI-samples/master/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_InferenceOptimization/scripts/freeze_optimize_v2.py
 
-Example:
+**Example:**
+
 ```bash
 python freeze_optimize.py \
   --input_saved_model_dir=/tmp/bert_large_hf/1 \
   --output_saved_model_dir=/tmp/bert_large_hf_frozen/1
 ```
+
 Run this after exporting the `SavedModel` (server side).
 
-----------------------------------------------------------------------
-Key Validation Steps
-----------------------------------------------------------------------
-- Functional: REST returns logits JSON
-- Precision: Logs show auto_mixed_precision_onednn_bfloat16
-- AMX: ONEDNN_VERBOSE lines include amx and bf16 datatypes
-- Rollback: Remove mixed_precision flag; delete policy in Keras path
+## Key Validation Steps
 
-----------------------------------------------------------------------
-Summary:
+- **Functional:** REST returns logits JSON
+- **Precision:** Logs show `auto_mixed_precision_onednn_bfloat16`
+- **AMX:** `ONEDNN_VERBOSE` lines include `amx` and `bf16` datatypes
+- **Rollback:** Remove `--mixed_precision` flag; delete policy in Keras path
+
+## Summary
+
 Enabled BF16 mixed precision on Xeon with minimal code change, deployed via TensorFlow Serving, verified AMX acceleration, and optionally optimized the model by freezing the graph.

--- a/software/tensorflow/nlp-transformers-bert/README.md
+++ b/software/tensorflow/nlp-transformers-bert/README.md
@@ -20,8 +20,9 @@ BERT (Bidirectional Encoder Representations from Transformers) is a transformer 
 
 ## Prerequisites
 
-- Intel Xeon 4th Gen (or newer) with AMX BF16 support
-- Python environment with pip
+- Intel Xeon 4th Gen (or newer) with AMX `bfloat16` support
+- Docker (for TensorFlow Serving deployment)
+- Python environment with `pip`
 - Internet access to download model weights
 
 ## Install Required Packages
@@ -94,7 +95,7 @@ def serving_fn(input_ids, attention_mask):
     return {"logits": tf.identity(logits, name="float32_output")}
 
 output_model_path = "/tmp/bert_large_hf/1"  # versioned directory
-model.save(output_model_path, include_optimizer=False, signatures={"serving_default": serving_fn})
+tf.saved_model.save(model, output_model_path, signatures={"serving_default": serving_fn})
 print("Exported to:", output_model_path)
 ```
 
@@ -186,7 +187,7 @@ resp = requests.post(
 
 if resp.status_code == 200:
     preds = np.array(resp.json()["predictions"])
-    print("Inference successful")
+    print("Inference successful!")
     logits = preds[0]
     probs = tf.nn.softmax(logits).numpy()
     print("Logits:", logits)
@@ -212,7 +213,7 @@ I0000 00:00:1758754431.978969    3797 auto_mixed_precision.cc:2263] Converted 18
 
 Logits and probabilities for binary classification (untrained weights will give random results):
 
-```bash
+```
 Inference successful!
 Logits: [-0.123 0.456]
 Probabilities: [0.412 0.588]
@@ -228,7 +229,7 @@ https://raw.githubusercontent.com/oneapi-src/oneAPI-samples/master/AI-and-Analyt
 **Example:**
 
 ```bash
-python freeze_optimize.py \
+python freeze_optimize_v2.py \
   --input_saved_model_dir=/tmp/bert_large_hf/1 \
   --output_saved_model_dir=/tmp/bert_large_hf_frozen/1
 ```

--- a/software/tensorflow/nlp-transformers-bert/README.md
+++ b/software/tensorflow/nlp-transformers-bert/README.md
@@ -6,7 +6,7 @@ Prerequisites
 - Python environment with pip
 - Internet access to download model weights
 
-Install Required Packages
+### Install Required Packages
 (Exact versions ensure consistency.)
 ```bash
 pip install tensorflow==2.20.0

--- a/software/tensorflow/nlp-transformers-bert/README.md
+++ b/software/tensorflow/nlp-transformers-bert/README.md
@@ -1,0 +1,204 @@
+# Natural Language Processing (NLP): Inference with BERT-Large (Uncased)
+BERT (Bidirectional Encoder Representations from Transformers) is a transformer model pretrained on large English text corpora using self-supervised objectives. This example shows how to run BERT-Large (uncased, Hugging Face) for sequence (binary) classification on Intel Xeon processors with AMX acceleration using bfloat16 (BF16) mixed precision.
+
+Prerequisites
+- Intel Xeon 4th Gen (or newer) with AMX BF16 support
+- Python environment with pip
+- Internet access to download model weights
+
+Install Required Packages
+(Exact versions ensure consistency.)
+```bash
+pip install tensorflow==2.20.0
+pip install tf-keras==2.20.1 --no-deps
+pip install transformers==4.49.0
+```
+
+To reuse the standard FP32 (pretrained) BERT-Large model while executing layers in BF16 on AMX, enable a `mixed_bfloat16` policy BEFORE creating/loading the model. This keeps model weights in FP32 for stability while executing math (matmul, attention, feed‑forward) in BF16 on AMX-capable Intel Xeon processors. Note that this approach to enable auto-mixed precision can be used for any Keras model.
+
+```python
+import tensorflow as tf
+from transformers import TFBertForSequenceClassification, BertTokenizer
+
+tf.keras.mixed_precision.set_global_policy("mixed_bfloat16")
+
+model_name = "bert-large-uncased"
+tokenizer = BertTokenizer.from_pretrained(model_name)
+model = TFBertForSequenceClassification.from_pretrained(model_name, num_labels=2)
+
+text = "This is a great movie!"
+inputs = tokenizer(text, return_tensors="tf", padding=True, truncation=True)
+
+outputs = model(
+    inputs["input_ids"],
+    attention_mask=inputs["attention_mask"],
+    training=False
+)
+
+logits = tf.cast(outputs.logits, tf.float32)  # ensure float32 for downstream usage
+pred = tf.argmax(logits, axis=-1)
+
+print("Logits:", logits.numpy())
+print("Predicted class:", pred.numpy())
+```
+Notes:
+- Set ONEDNN_VERBOSE=1 to confirm AMX usage (look for brg_matmul ... amx).
+- Revert to full FP32 by removing the policy or setting mixed_precision to float32.
+
+----------------------------------------------------------------------
+Deploying with TensorFlow Serving (BF16 Auto Mixed Precision)
+----------------------------------------------------------------------
+
+1. Export the Model (SavedModel, FP32 weights)
+```python
+import tensorflow as tf
+from transformers import TFBertForSequenceClassification, BertTokenizer
+
+model_name = "bert-large-uncased"
+tokenizer = BertTokenizer.from_pretrained(model_name)
+model = TFBertForSequenceClassification.from_pretrained(model_name, num_labels=2)
+
+@tf.function(input_signature=[
+    tf.TensorSpec([None, None], tf.int32, name="input_ids"),
+    tf.TensorSpec([None, None], tf.int32, name="attention_mask")
+])
+def serving_fn(input_ids, attention_mask):
+    out = model(input_ids, attention_mask=attention_mask, training=False)
+    logits = tf.cast(out.logits, tf.float32)
+    return {"logits": tf.identity(logits, name="float32_output")}
+
+output_model_path = "/tmp/bert_large_hf/1"  # versioned directory
+model.save(output_model_path, include_optimizer=False, signatures={"serving_default": serving_fn})
+print("Exported to:", output_model_path)
+```
+Run:
+```bash
+python export_bert_large.py
+```
+
+2. Pull TensorFlow Serving
+(Using the official CPU image.)
+```bash
+docker pull tensorflow/serving
+```
+Reference setup guide: https://github.com/tensorflow/serving?tab=readme-ov-file#set-up
+
+3. Start the Server (Enable BF16)
+TensorFlow Serving (CPU) currently supports bfloat16 mixed precision (fp16 not yet enabled for CPU).
+```bash
+docker run -t --rm \
+  -p 8501:8501 \
+  -v /tmp/bert_large_hf:/models/bert_large_hf \
+  -e MODEL_NAME=bert_large_hf \
+  -e ONEDNN_VERBOSE=1 \
+  tensorflow/serving --mixed_precision=bfloat16
+```
+Sample log indicators:
+- `auto_mixed_precision_onednn_bfloat16` graph optimizer
+- `brg_matmul` with `amx` and `src_bf16` / `wei_bf16`
+
+```bash
+2025-09-24 22:45:48.953387: I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:220] Running initialization op on SavedModel bundle at path: /models/bert_large_hf/1
+I0000 00:00:1758753949.448357     905 auto_mixed_precision.cc:2335] Running auto_mixed_precision_onednn_bfloat16 graph optimizer
+I0000 00:00:1758753949.450298     905 auto_mixed_precision.cc:1511] No allowlist ops found, nothing to do
+2025-09-24 22:45:49.465449: I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:471] SavedModel load for tags { serve }; Status: success: OK. Took 3153824 microseconds.
+2025-09-24 22:45:50.229979: I tensorflow_serving/model_servers/server.cc:428] Running gRPC ModelServer at 0.0.0.0:8500 ...
+2025-09-24 22:45:50.292271: I tensorflow_serving/model_servers/server.cc:449] Exporting HTTP/REST API at:localhost:8501 ...
+```
+
+Troubleshooting 403:
+- Ensure URL model name matches MODEL_NAME.
+- Check container logs: docker logs <id>.
+- Disable proxies: export no_proxy=localhost,127.0.0.1.
+
+----------------------------------------------------------------------
+Client Inference (REST)
+----------------------------------------------------------------------
+Install:
+```bash
+pip install requests==2.32.5 numpy==2.3.3 transformers==4.49.0 tensorflow==2.20.0
+pip install tf-keras==2.20.1 --no-deps
+```
+
+Create infer_bert_large.py:
+```python
+import requests, json, numpy as np, tensorflow as tf
+from transformers import BertTokenizer
+
+tokenizer = BertTokenizer.from_pretrained("bert-large-uncased")
+text = "I love this product!"
+inputs = tokenizer(
+    text,
+    return_tensors="tf",
+    max_length=128,
+    padding="max_length",
+    truncation=True
+)
+
+payload = {
+    "instances": [{
+        "input_ids": inputs["input_ids"][0].numpy().tolist(),
+        "attention_mask": inputs["attention_mask"][0].numpy().tolist()
+    }]
+}
+
+resp = requests.post(
+    "http://127.0.0.1:8501/v1/models/bert_large_hf:predict",
+    data=json.dumps(payload),
+    headers={"content-type": "application/json"},
+    proxies={"http": None, "https": None}
+)
+
+if resp.status_code == 200:
+    preds = np.array(resp.json()["predictions"])
+    print("Inference successful")
+    logits = preds[0]
+    probs = tf.nn.softmax(logits).numpy()
+    print("Logits:", logits)
+    print("Probabilities:", probs)
+else:
+    print("Error:", resp.text)
+```
+Run:
+```bash
+python infer_bert_large.py
+```
+
+**Expected Logs on the Server**
+
+```bash
+I0000 00:00:1758754431.951130    3797 auto_mixed_precision.cc:2335] Running auto_mixed_precision_onednn_bfloat16 graph optimizer
+I0000 00:00:1758754431.978969    3797 auto_mixed_precision.cc:2263] Converted 1837/4155 nodes to bfloat16 precision using 2 cast(s) to bfloat16 (excluding Const and Variable casts)
+```
+
+**Expected Logs on the Client**
+
+Logits and probabilities for binary classification (untrained weights will give random results):
+
+----------------------------------------------------------------------
+Optional: Graph Freezing for Additional Performance
+----------------------------------------------------------------------
+Freeze variables to constants for a lean inference graph (removes variable-loading overhead).
+
+Script (public reference):
+https://raw.githubusercontent.com/oneapi-src/oneAPI-samples/master/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_InferenceOptimization/scripts/freeze_optimize_v2.py
+
+Example:
+```bash
+python freeze_optimize.py \
+  --input_saved_model_dir=/tmp/bert_large_hf/1 \
+  --output_saved_model_dir=/tmp/bert_large_hf_frozen/1
+```
+Run this after exporting the `SavedModel` (server side).
+
+----------------------------------------------------------------------
+Key Validation Steps
+----------------------------------------------------------------------
+- Functional: REST returns logits JSON
+- Precision: Logs show auto_mixed_precision_onednn_bfloat16
+- AMX: ONEDNN_VERBOSE lines include amx and bf16 datatypes
+- Rollback: Remove mixed_precision flag; delete policy in Keras path
+
+----------------------------------------------------------------------
+Summary:
+Enabled BF16 mixed precision on Xeon with minimal code change, deployed via TensorFlow Serving, verified AMX acceleration, and optionally optimized the model by freezing the graph.

--- a/software/tensorflow/nlp-transformers-bert/README.md
+++ b/software/tensorflow/nlp-transformers-bert/README.md
@@ -212,6 +212,12 @@ I0000 00:00:1758754431.978969    3797 auto_mixed_precision.cc:2263] Converted 18
 
 Logits and probabilities for binary classification (untrained weights will give random results):
 
+```bash
+Inference successful!
+Logits: [-0.123 0.456]
+Probabilities: [0.412 0.588]
+```
+
 ## Optional: Graph Freezing for Additional Performance
 
 Freeze variables to constants for a lean inference graph (removes variable-loading overhead).


### PR DESCRIPTION
Adds documentation under `software/tensorflow/` for leveraging Intel AMX acceleration with TensorFlow, including:

- **Quick-start guide** (`README.md`) — environment setup, BF16 matrix multiplication benchmark, and AMX verification via oneDNN verbose logging.
- **NLP — BERT-Large** (`nlp-transformers-bert/`) — sequence classification with Hugging Face Transformers, Keras mixed precision, TF Serving deployment, and REST client inference.
- **GNN — RGAT** (`graph-neural-networks-rgat/`) — relational graph attention network inference using TF-GNN with `GATv2Conv`, TF Serving deployment, and REST client inference.
- **CV — ResNet50 v1.5** (`computer-vision-resnet50/`) — image classification with Keras built-in ResNet50, mixed precision, TF Serving deployment, and optional graph freezing.

Each guide covers Keras `mixed_bfloat16` setup, model export, Docker-based TF Serving with `--mixed_precision=bfloat16`, client code, and AMX verification steps.